### PR TITLE
fix j1939 documentation: change jacd to j1939acd

### DIFF
--- a/Documentation/networking/j1939.rst
+++ b/Documentation/networking/j1939.rst
@@ -376,7 +376,7 @@ only j1939.addr changed to the new SA, and must then send a valid address claim
 packet. This restarts the state machine in the kernel (and any other
 participant on the bus) for this NAME.
 
-can-utils also include the jacd tool, so it can be used as code example or as
+can-utils also include the j1939acd tool, so it can be used as code example or as
 default Address Claiming daemon.
 
 Send Examples


### PR DESCRIPTION
Signed-off-by: Michael Josenhans <michael.josenhans@web.de>

Change name of jacd to j1939acd, as it been renamed in the can-utils repo, to avoid name collisions.